### PR TITLE
Fix libp2p-close

### DIFF
--- a/libp2p/client.ss
+++ b/libp2p/client.ss
@@ -194,11 +194,12 @@
 (def (libp2p-close c)
   (with ((client _ mx _ _ sock thread) c)
     (with-lock mx
-      (when sock
-        (ssocket-close sock)
-        (thread-group-kill! (thread-thread-group thread))
-        (set! (client-sock c) #f)
-        (set! (client-thread c) #f)))))
+      (lambda ()
+        (when sock
+          (ssocket-close sock)
+          (thread-group-kill! (thread-thread-group thread))
+          (set! (client-sock c) #f)
+          (set! (client-thread c) #f))))))
 
 (def (libp2p-list-peers c)
   (let (res (control-request c (Request type: 'LIST_PEERS) Response-peers))


### PR DESCRIPTION
Encountered the following error when using `libp2p-close`:
```
*** ERROR IN ##start-main -- (Argument 2) PROCEDURE expected
(dynamic-wind '#<procedure #25> #!void '#<procedure #26>)
```

`with-lock` should take in procedure instead:
```
(with-lock mx thunk) -> any

  mx    := mutex
  thunk := procedure
```

