### PR TITLE
Update uses of loggers

### DIFF
--- a/example/libp2p-echo.ss
+++ b/example/libp2p-echo.ss
@@ -11,6 +11,8 @@
         :vyzo/libp2p)
 (export main)
 
+(deflogger libp2p)
+
 (def echo-proto "/echo/1.0.0")
 
 (def (register-echo-handler! c)
@@ -20,7 +22,7 @@
 ;; reads a line of text, echoes it back, and closes the stream
 ;; this implementation reads up to 4k chars because I don't like unbounded reads.
 (def (echo-handler s)
-  (debug "New stream from ~a" (peer-info->string (cdr (stream-info s))))
+  (debugf "New stream from ~a" (peer-info->string (cdr (stream-info s))))
   (let (line (bio-read-line (stream-in s) #\newline #t 4096))
     (unless (eof-object? line)
       (bio-write-string line (stream-out s))

--- a/libp2p/client.ss
+++ b/libp2p/client.ss
@@ -16,7 +16,9 @@
         :vyzo/libp2p/peer
         :vyzo/libp2p/multiaddr
         :vyzo/libp2p/pb/p2pd)
-(export #t)
+(export (except-out #t errorf warnf infof debugf verbosef))
+
+(deflogger libp2p)
 
 (defstruct (libp2p-error <error>) ())
 
@@ -180,14 +182,14 @@
 
            (dispatch-handler handler s)))
      (else
-      (warning "Incoming stream for unknown protocol: ~a" (car info))
+      (warnf "Incoming stream for unknown protocol: ~a" (car info))
       (stream-close s)))))
 
 (def (dispatch-handler handler s)
   (try
    (handler s)
    (catch (e)
-     (log-error "Unhandled exception" e)
+     (errorf "Unhandled exception: ~a" e)
      (stream-close s))))
 
 


### PR DESCRIPTION
After https://github.com/vyzo/gerbil/pull/638 the interface to `:std/logger` has changed. This PR updates it to use the new interface.