### PR TITLE
Peerinfo parsing fix

### DIFF
--- a/libp2p/peer.ss
+++ b/libp2p/peer.ss
@@ -41,16 +41,20 @@
 (def (string->peer-info str)
   (match (reverse (pregexp-split ipfs-part-rx str))
     ([id . rest]
-     (peer-info (string->ID id)
+     (peer-info (if (equal? rest '())
+                  (error "Malformed peer info" str)
+                  (string->ID id))
                 (let ((maddr (string-append-with-ipfs (reverse rest))))
-                (if (string-empty? maddr)
-                  []
-                  [(string->multiaddr maddr)]))))
+                  (if (string-empty? maddr)
+                    []
+                    [(string->multiaddr maddr)]))))
     (else
      (error "Malformed peer info" str))))
 
 (def (string-append-with-ipfs lst)
-  (if (equal? (cdr lst) '())
-    (car lst)
-    (apply string-append
-      (list (car lst) "/ipfs/" (string-append-with-ipfs (cdr lst))))))
+  (if (equal? lst '())
+    ""
+    (if (equal? (cdr lst) '())
+      (car lst)
+      (apply string-append
+           (list (car lst) "/ipfs/" (string-append-with-ipfs (cdr lst)))))))

--- a/libp2p/peer.ss
+++ b/libp2p/peer.ss
@@ -50,11 +50,3 @@
                     [(string->multiaddr maddr)]))))
     (else
      (error "Malformed peer info" str))))
-
-(def (string-append-with-ipfs lst)
-  (if (equal? lst '())
-    ""
-    (if (equal? (cdr lst) '())
-      (car lst)
-      (apply string-append
-           (list (car lst) "/ipfs/" (string-append-with-ipfs (cdr lst)))))))

--- a/libp2p/peer.ss
+++ b/libp2p/peer.ss
@@ -39,11 +39,18 @@
   (pregexp "/ipfs/"))
 
 (def (string->peer-info str)
-  (match (pregexp-split ipfs-part-rx str)
-    ([maddr id]
+  (match (reverse (pregexp-split ipfs-part-rx str))
+    ([id . rest]
      (peer-info (string->ID id)
+                (let ((maddr (string-append-with-ipfs (reverse rest))))
                 (if (string-empty? maddr)
                   []
-                  [(string->multiaddr maddr)])))
+                  [(string->multiaddr maddr)]))))
     (else
      (error "Malformed peer info" str))))
+
+(def (string-append-with-ipfs lst)
+  (if (equal? (cdr lst) '())
+    (car lst)
+    (apply string-append
+      (list (car lst) "/ipfs/" (string-append-with-ipfs (cdr lst))))))

--- a/libp2p/peer.ss
+++ b/libp2p/peer.ss
@@ -41,10 +41,10 @@
 (def (string->peer-info str)
   (match (reverse (pregexp-split ipfs-part-rx str))
     ([id . rest]
-     (peer-info (if (equal? rest '())
+     (peer-info (if (null? rest)
                   (error "Malformed peer info" str)
                   (string->ID id))
-                (let ((maddr (string-append-with-ipfs (reverse rest))))
+                (let ((maddr (string-join (reverse rest) "/ipfs/")))
                   (if (string-empty? maddr)
                     []
                     [(string->multiaddr maddr)]))))


### PR DESCRIPTION
# Overview

This is to address issue #16 

Rather than assuming that "/ipfs/" only occurs once in a correct address, string->peer-info now assumes it occurs >=1 times in a correct address

This is done only putting the last occurrence of "/ipfs/" into the ID , while the rest of the string goes into the multiaddr.