### PR TITLE
Factor out start-a-libp2p-daemon!

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ You don't normally have to start the daemon, as `open-libp2p-client` will start 
 automatically. But you may want to control the `p2pd` executable path and options or
 want to reuse a running daemon.
 
-#### start-libp2p-daemon!
+#### start-the-libp2p-daemon!
 ```
-(start-libp2p-daemon! [daemon: (daemon "p2pd")]
-                      [options: (options [])]
-                      [address: (address #f)]
-                      [wait: (wait .4)])
+(start-the-libp2p-daemon! [daemon: (daemon "p2pd")]
+                          [options: (options [])]
+                          [address: (address #f)]
+                          [wait: (wait .4)])
  daemon  := string; the daemon executable
  options := list of strings; options to pass to the daemon
  address := daemon unix socket path
@@ -76,7 +76,7 @@ Ensures that a daemon is running, and starts it if there isn't one.
 (stop-libp2p-daemon! [daemon = (current-libp2p-daemon)])
 ```
 
-Kills the libp2p daemon if it was started with `start-libp2p-daemon!`.
+Kills the libp2p daemon if it was started with `start-the-libp2p-daemon!`.
 
 #### use-libp2p-daemon!
 ```

--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ You don't normally have to start the daemon, as `open-libp2p-client` will start 
 automatically. But you may want to control the `p2pd` executable path and options or
 want to reuse a running daemon.
 
+#### start-libp2p-daemon!
+```
+(start-libp2p-daemon! [daemon: (daemon "p2pd")]
+                      [options: (options [])]
+                      [address: (address #f)]
+                      [wait: (wait .4)])
+ daemon  := string; the daemon executable
+ options := list of strings; options to pass to the daemon
+ address := daemon unix socket path
+ wait    := how long to wait for daemon to initialize
+=> <daemon>
+```
+
+Starts a new daemon running without regard to `current-libp2p-daemon`.
+If a daemon is already running at `current-libp2p-daemon`,
+this ignores that and creates a new one anyway.
+
 #### start-the-libp2p-daemon!
 ```
 (start-the-libp2p-daemon! [daemon: (daemon "p2pd")]
@@ -69,14 +86,25 @@ want to reuse a running daemon.
 => <daemon>
 ```
 
-Ensures that a daemon is running, and starts it if there isn't one.
+Ensures that a daemon is running at `current-libp2p-daemon`,
+and starts and sets it only if there isn't one already.
 
 #### stop-libp2p-daemon!
 ```
 (stop-libp2p-daemon! [daemon = (current-libp2p-daemon)])
 ```
 
-Kills the libp2p daemon if it was started with `start-the-libp2p-daemon!`.
+Kills the given libp2p daemon if it was started with `start-libp2p-daemon!`.
+This does not change the value inside `current-libp2p-daemon`,
+even if the `daemon` argument is not provided or is equal to that value.
+
+#### stop-the-libp2p-daemon!
+```
+(stop-the-libp2p-daemon!)
+```
+
+Kills the libp2p daemon at `current-libp2p-daemon`,
+and sets the `current-libp2p-daemon` to false.
 
 #### use-libp2p-daemon!
 ```
@@ -85,7 +113,7 @@ Kills the libp2p daemon if it was started with `start-the-libp2p-daemon!`.
 => <daemon>
 ```
 
-Sets the current daemon to an external process with `path` as the unix control
+Sets the `current-libp2p-daemon` to an external process with `path` as the unix control
 socket path.
 
 

--- a/example/dht-crawl.ss
+++ b/example/dht-crawl.ss
@@ -42,7 +42,7 @@
     (lambda (file)
       (start-logger!)
       (debugf "Starting p2pd")
-      (start-libp2p-daemon! host-addresses: addresses options: ["-b" "-dhtClient" "-connManager"] wait: 10)
+      (start-the-libp2p-daemon! host-addresses: addresses options: ["-b" "-dhtClient" "-connManager"] wait: 10)
       (debugf "Starting indefinite crawl; output to ~a" filename)
       (crawl! file workers addresses))))
 

--- a/example/libp2p-chat-with-circuit-relay.ss
+++ b/example/libp2p-chat-with-circuit-relay.ss
@@ -162,7 +162,7 @@
 
 ;;start a libp2p daemon that allows for circuit relays
 (def (do-circuit-relay host-addresses)
-  (let* ((d (start-libp2p-daemon! host-addresses: host-addresses options: ["-relayHop"] wait: 20))
+  (let* ((d (start-the-libp2p-daemon! host-addresses: host-addresses options: ["-relayHop"] wait: 20))
          (c (open-libp2p-client host-addresses: host-addresses wait: 20)))
     (for (p (peer-info->string* (libp2p-identify c)))
       (displayln "I am " p))

--- a/example/pubsub-chat.ss
+++ b/example/pubsub-chat.ss
@@ -92,7 +92,7 @@
    (displayln "starting up")
 
    ;start the daemon with custom arguments -pubsub and -connManager to enable pubsub
-   (start-libp2p-daemon! host-addresses: host-addresses options: ["-pubsub" "-connManager"] wait: 10)
+   (start-the-libp2p-daemon! host-addresses: host-addresses options: ["-pubsub" "-connManager"] wait: 10)
 
    ;open a client with the given host-address, it will use the daemon already running
   (let* ((c (open-libp2p-client host-addresses: host-addresses wait: 10))

--- a/libp2p.ss
+++ b/libp2p.ss
@@ -13,8 +13,8 @@
 (export
   ;; :vyzo/libp2p/daemon
   current-libp2p-daemon
+  start-the-libp2p-daemon!
   start-libp2p-daemon!
-  start-a-libp2p-daemon!
   stop-libp2p-daemon!
   stop-the-libp2p-daemon!
   use-libp2p-daemon!

--- a/libp2p.ss
+++ b/libp2p.ss
@@ -14,7 +14,9 @@
   ;; :vyzo/libp2p/daemon
   current-libp2p-daemon
   start-libp2p-daemon!
+  start-a-libp2p-daemon!
   stop-libp2p-daemon!
+  stop-the-libp2p-daemon!
   use-libp2p-daemon!
   ;; :vyzo/libp2p/client
   libp2p-error?

--- a/libp2p/client.ss
+++ b/libp2p/client.ss
@@ -59,7 +59,7 @@
           (raise e)))))
 
 (def (open-libp2p-client host-addresses: (host-addresses #f) options: (args [])  address: (sock #f)  wait: (timeo 12) (path #f)) ;; Extra arguments host-address and options
-  (let (d (start-libp2p-daemon! host-addresses: host-addresses options: args address: sock wait: timeo)) ;; Should go with host-address/tranpsort/port
+  (let (d (start-the-libp2p-daemon! host-addresses: host-addresses options: args address: sock wait: timeo)) ;; Should go with host-address/tranpsort/port
     (make-client d (make-mutex 'libp2p-client) (make-hash-table) path #f #f)))
 
 (def (open-stream c bufsz)

--- a/libp2p/daemon.ss
+++ b/libp2p/daemon.ss
@@ -16,26 +16,26 @@
 
 ;; Starts a new libp2p-daemon only if there is no existing current-libp2p-daemon,
 ;; and if so sets the current-libp2p-daemon to the new one.
-(def (start-libp2p-daemon! host-addresses: (host-addrs #f) daemon: (bin "p2pd")
-                           options: (args [])
-                           address: (sock #f)
-                           wait: (timeo 0.4))
+(def (start-the-libp2p-daemon! host-addresses: (host-addrs #f) daemon: (bin "p2pd")
+                               options: (args [])
+                               address: (sock #f)
+                               wait: (timeo 0.4))
   (cond
    ((current-libp2p-daemon)
     => values)
    (else
-    (let ((d (start-a-libp2p-daemon! host-addresses: host-addrs daemon: bin
-                                     options: args
-                                     address: sock
-                                     wait: timeo)))
+    (let ((d (start-libp2p-daemon! host-addresses: host-addrs daemon: bin
+                                   options: args
+                                   address: sock
+                                   wait: timeo)))
      (current-libp2p-daemon d)
      d))))
 
 ;; Starts a libp2p-daemon without regard to current-libp2p-daemon
-(def (start-a-libp2p-daemon! host-addresses: (host-addrs #f) daemon: (bin "p2pd")
-                             options: (args [])
-                             address: (sock #f)
-                             wait: (timeo 0.4))
+(def (start-libp2p-daemon! host-addresses: (host-addrs #f) daemon: (bin "p2pd")
+                           options: (args [])
+                           address: (sock #f)
+                           wait: (timeo 0.4))
     (let* ((path (or sock (string-append "/tmp/p2pd." (number->string (getpid)) ".sock")))
            (addr (string-append "/unix" path))
            (proc (if host-addrs

--- a/libp2p/daemon.ss
+++ b/libp2p/daemon.ss
@@ -14,6 +14,8 @@
 (def current-libp2p-daemon
   (make-parameter #f))
 
+;; Starts a new libp2p-daemon only if there is no existing current-libp2p-daemon,
+;; and if so sets the current-libp2p-daemon to the new one.
 (def (start-libp2p-daemon! host-addresses: (host-addrs #f) daemon: (bin "p2pd")
                            options: (args [])
                            address: (sock #f)
@@ -22,6 +24,18 @@
    ((current-libp2p-daemon)
     => values)
    (else
+    (let ((d (start-a-libp2p-daemon! host-addresses: host-addrs daemon: bin
+                                     options: args
+                                     address: sock
+                                     wait: timeo)))
+     (current-libp2p-daemon d)
+     d))))
+
+;; Starts a libp2p-daemon without regard to current-libp2p-daemon
+(def (start-a-libp2p-daemon! host-addresses: (host-addrs #f) daemon: (bin "p2pd")
+                             options: (args [])
+                             address: (sock #f)
+                             wait: (timeo 0.4))
     (let* ((path (or sock (string-append "/tmp/p2pd." (number->string (getpid)) ".sock")))
            (addr (string-append "/unix" path))
            (proc (if host-addrs
@@ -32,8 +46,7 @@
        ((process-status proc timeo #f)
         => (lambda (status)
              (error "p2pd exited prematurely" status))))
-      (current-libp2p-daemon d)
-      d))))
+      d))
 
 (def (stop-libp2p-daemon! (d (current-libp2p-daemon)))
   (with ((daemon proc path) d)
@@ -44,6 +57,10 @@
         (when (file-exists? path)
           (delete-file path))
         status))))
+
+(def (stop-the-libp2p-daemon!)
+  (stop-libp2p-daemon!)
+  (current-libp2p-daemon #f))
 
 (def (use-libp2p-daemon! path)
   (current-libp2p-daemon (daemon #f path)))


### PR DESCRIPTION
 - `start-libp2p-daemon!` for "a" daemon
 - `stop-libp2p-daemon!` for "a" daemon
 - `start-the-libp2p-daemon!` for "the" daemon in `current-libp2p-daemon`
 - `stop-the-libp2p-daemon!` for "the" daemon in `current-libp2p-daemon`

See also https://github.com/vyzo/gerbil-libp2p/issues/20